### PR TITLE
fromExample should return Option

### DIFF
--- a/core/src/main/scala/com/spotify/tfexample/derive/ExampleConverter.scala
+++ b/core/src/main/scala/com/spotify/tfexample/derive/ExampleConverter.scala
@@ -21,7 +21,7 @@ import org.tensorflow.example.Example
 
 trait ExampleConverter[T] {
   def toExample(record: T): Example
-  def fromExample(example: Example): T
+  def fromExample(example: Example): Option[T]
 }
 
 object ExampleConverter {

--- a/core/src/main/scala/com/spotify/tfexample/derive/Implicits.scala
+++ b/core/src/main/scala/com/spotify/tfexample/derive/Implicits.scala
@@ -101,7 +101,8 @@ trait Implicits {
           .build()
       }
 
-      override def fromExample(example: Example): T = fb.fromFeatures(example.getFeatures, None)
+      override def fromExample(example: Example): Option[T] =
+        Try(fb.fromFeatures(example.getFeatures, None)).toOption
     }
 
   private def featuresOf(name: Option[String], feature: Feature): Features.Builder =


### PR DESCRIPTION
The `Example -> T` direction is unsafe, especially for backend services that may run into incomplete / malformed examples. This should return `Option` for type safety.